### PR TITLE
for_production: validate tasks before running them

### DIFF
--- a/for_production.sh
+++ b/for_production.sh
@@ -35,7 +35,7 @@ init "$@"
 	# TODO: copy the data explicitly from manager to controller here
     # e.g. `rsync -avr "$WORKDIR" --port $CONTROLLERPORT ocrd@$CONTROLLERHOST:/data`
 
-    ocrd_exec ocrd_import_workdir ocrd_process_workflow
+    ocrd_exec ocrd_import_workdir pre_process_validate_workflow ocrd_process_workflow
 
     # TODO: copy the results back here
     # e.g. `rsync -avr --port $CONTROLLERPORT ocrd@$CONTROLLERHOST:/data/"$WORKDIR" "$WORKDIR"`

--- a/for_production.sh
+++ b/for_production.sh
@@ -35,10 +35,12 @@ init "$@"
 	# TODO: copy the data explicitly from manager to controller here
     # e.g. `rsync -avr "$WORKDIR" --port $CONTROLLERPORT ocrd@$CONTROLLERHOST:/data`
 
-    ocrd_exec ocrd_import_workdir pre_process_validate_workflow ocrd_process_workflow
+    ocrd_exec ocrd_import_workdir ocrd_validate_workflow ocrd_process_workflow
 
     # TODO: copy the results back here
     # e.g. `rsync -avr --port $CONTROLLERPORT ocrd@$CONTROLLERHOST:/data/"$WORKDIR" "$WORKDIR"`
+    # maybe also schedule cleanup (or have a cron job delete dirs in /data which are older than N days)
+    # e.g. `ssh --port $CONTROLLERPORT ocrd@$CONTROLLERHOST rm -fr /data/"$WORKDIR"`
 
     post_process_validate_workdir
 

--- a/ocr.sh
+++ b/ocr.sh
@@ -96,7 +96,7 @@ pre_process_to_workdir () {
 }
 
 pre_process_validate_workflow () {
-    echo -n "ocrd validate tasks "
+    echo -n "ocrd validate tasks --workspace . "
     ocrd_format_workflow
 }
 

--- a/ocr.sh
+++ b/ocr.sh
@@ -95,7 +95,7 @@ pre_process_to_workdir () {
     cp -vr --reflink=auto "$PROCDIR/$PROCIMAGEDIR" "$WORKDIR" | logger -p user.info -t $TASK
 }
 
-pre_process_validate_workflow () {
+ocrd_validate_workflow () {
     echo -n "ocrd validate tasks --workspace . "
     ocrd_format_workflow
 }


### PR DESCRIPTION
(validation must run on target=controller, because tools are only installed there – so we should probably rename `pre_process_validate_workflow` to `ocrd_validate_workflow`)
