### PR TITLE
ocrd_exec: use non-tty SSH command again (otherwise will not terminate)

### DIFF
--- a/ocrd_lib.sh
+++ b/ocrd_lib.sh
@@ -138,7 +138,7 @@ ocrd_exec() {
     for param in "$@"; do
       $param
     done
-  } | ssh -tt -p "${CONTROLLERPORT}" ocrd@${CONTROLLERHOST} 2>&1
+  } | ssh -T -p "${CONTROLLERPORT}" ocrd@${CONTROLLERHOST} 2>&1
 }
 
 pre_process_to_workdir() {


### PR DESCRIPTION
(does seem necessary for termination after all)